### PR TITLE
Fix #26. Exclude 'Form' tag from ElementsFlags

### DIFF
--- a/src/Jsonize.Test/Program.cs
+++ b/src/Jsonize.Test/Program.cs
@@ -141,7 +141,7 @@ namespace Jsonize_Test
         }
 
         [Test]
-        public async Task TestFormNodeShouldBeNode()
+        public void TestFormNodeShouldBeNode()
         {
             JsonizeConfiguration jsonizeConfiguration = new JsonizeConfiguration();
 
@@ -151,7 +151,7 @@ namespace Jsonize_Test
             Assert.AreEqual("{\"node\":\"Document\",\"child\":[{\"tag\":\"html\",\"child\":[{\"tag\":\"head\"},{\"tag\":\"body\",\"child\":[{\"tag\":\"form\"}]}]}]}", 
                 result.Replace("\r\n", "").Replace(" ", ""));
         }
-
+        
         private static async Task<JsonizeNode> TestJsonizeAsJsonizeNode()
         {
             if (_html == null)

--- a/src/jsonize/Jsonize.cs
+++ b/src/jsonize/Jsonize.cs
@@ -43,6 +43,8 @@ namespace JackWFinlay.Jsonize
         /// </summary>
         public Jsonize()
         {
+            // Fix #26: Form tag parsed as a text node.
+            HtmlNode.ElementsFlags.Remove("form");
             _htmlDoc = _htmlDoc ?? new HtmlDocument();
             _emptyTextNodeHandling = JsonizeConfiguration.DefaultEmptyTextNodeHandling;
             _nullValueHandling = JsonizeConfiguration.DefaultNullValueHandling;


### PR DESCRIPTION
Fix #26 
As I can see it the feature of the HtmlAgilityPack (for HTML 3.2). And one of the workarounds is exclude "form" from `ElementsFlags` dictionary.
